### PR TITLE
Record associate scan numbers in the config file

### DIFF
--- a/nsls2ptycho/core/ptycho_param.py
+++ b/nsls2ptycho/core/ptycho_param.py
@@ -140,6 +140,7 @@ class Param(object):
         self.cal_error_flag = True  # whether to calculate error in chi (fields)
         self.save_config_history = True 
         self.postprocessing_flag = True  # whether to call save_recon() to output and process results
+        self.asso_scan_numbers = []  # a list of scan numbers associated with scan_num
 
         self.init_obj_dpc_flag = False
         self.prb_center_flag = False

--- a/nsls2ptycho/ptycho_gui.py
+++ b/nsls2ptycho/ptycho_gui.py
@@ -338,6 +338,15 @@ class MainWindow(QtWidgets.QMainWindow, ui_ptycho.Ui_MainWindow):
 
         # batch param group, necessary?
 
+        # from the associate scan number window
+        if self._extra_scans_dialog is not None:
+            scans = self._extra_scans_dialog.listWidget
+            num_items = scans.count()
+            p.asso_scan_numbers = [scans.item(i).text() for i in range(num_items)]
+        else:
+            # do not erase this, as keeping it has no harm
+            pass
+
 
     def update_gui_from_param(self):
         p = self.param
@@ -803,6 +812,11 @@ class MainWindow(QtWidgets.QMainWindow, ui_ptycho.Ui_MainWindow):
         if self._extra_scans_dialog is None:
             self._extra_scans_dialog = ListWidget()
             self._extra_scans_dialog.setWindowTitle('Set associated scan numbers')
+            # read from param if there are any asso scans leftover from last time
+            p = self.param
+            if len(p.asso_scan_numbers) > 0:
+                scans = self._extra_scans_dialog.listWidget
+                scans.addItems([str(item) for item in p.asso_scan_numbers])
         self._extra_scans_dialog.show()
             
 
@@ -1386,6 +1400,8 @@ class MainWindow(QtWidgets.QMainWindow, ui_ptycho.Ui_MainWindow):
                 self.roiWindow.close()
             if self.scanWindow is not None:
                 self.scanWindow.close()
+            if self._extra_scans_dialog is not None:
+                self._extra_scans_dialog.close()
             event.accept()
         else:
             event.ignore()


### PR DESCRIPTION
Close #80.

This PR addresses the issue that the associate scan numbers are not recorded during GUI shutdown.

The accompanying PR for the backend is NSLS-II/ptycho#48.
