### PR TITLE
Fix scaler data by removing zeros (HXN)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__
 
 .idea
 .vscode
+
+build/
+nsls2ptycho.egg-info/

--- a/nsls2ptycho/core/HXN_databroker.py
+++ b/nsls2ptycho/core/HXN_databroker.py
@@ -109,8 +109,8 @@ def load_metadata(db, scan_num:int, det_name:str):
         if v > 0:
             ic_closest_nonzero = v
             break
-    if ic_closest_nonzero is None:
-        for n in ic.size:
+    if ic_closest_nonzero is not None:
+        for n in range(ic.size):
             if ic[n] <= 0:
                 print(
                     f"Scaler value {ic[n]} with index {n} is replaced "

--- a/nsls2ptycho/core/HXN_databroker.py
+++ b/nsls2ptycho/core/HXN_databroker.py
@@ -39,14 +39,23 @@ def array_ensure_positive_elements(arr, name="array"):
     Parameters
     ----------
     arr: numpy.ndarray
-        1D numpy array
+        Reference to 1D numpy array. The values are modified in place.
     name: str
         Data name to use in error messages.
+
+    Returns
+    -------
+    None
     """
     n_items_to_replace = sum(arr <= 0)
+
+    # Exit right away if there scaler data is valid (this should be true for correctly recorded scans)
     if not n_items_to_replace:
         return
 
+    # TODO: the algorithm may be implemented more efficiently if needed. Scalers are loaded only once
+    #       per reconstruction, and the correction does not introduce noticable delay. Rewrite
+    #       the function if performance becomes an issue.
     v_closest_positive = None
     for v in arr:  # Initialize the algorithm with some valid value in case the 1st element is zero.
         if v > 0:

--- a/nsls2ptycho/core/HXN_databroker.py
+++ b/nsls2ptycho/core/HXN_databroker.py
@@ -34,7 +34,11 @@ except FileNotFoundError:
 def array_ensure_positive_elements(arr, name="array"):
     """
     Replace all zero or negative values in the array with the closest positive values.
-    Works only with 1D arrays.
+    Works only with 1D arrays. The array is processed in the reversed order to replace
+    zeros with the following (not preceding) values, because they are more likely to
+    be from the same subscan (HXN).
+
+    The function will do nothing if there are no zeros or negative values in the array.
 
     Parameters
     ----------
@@ -57,14 +61,16 @@ def array_ensure_positive_elements(arr, name="array"):
     #       per reconstruction, and the correction does not introduce noticable delay. Rewrite
     #       the function if performance becomes an issue.
     v_closest_positive = None
-    for v in arr:  # Initialize the algorithm with some valid value in case the 1st element is zero.
+    for v in np.flip(
+        arr
+    ):  # Initialize the algorithm with some valid value in case the 1st element is zero.
         if v > 0:
             v_closest_positive = v
             break
 
     n_replaced = 0
     if v_closest_positive is not None:
-        for n in range(arr.size):
+        for n in reversed(range(arr.size)):
             if arr[n] <= 0:
                 print(
                     f"{name.capitalize()} value {arr[n]} with index {n} is replaced "
@@ -77,7 +83,9 @@ def array_ensure_positive_elements(arr, name="array"):
             else:
                 v_closest_positive = arr[n]
     else:
-        print(f"The {name} contains no positive non-zero values. Computations are likely to fail.")
+        print(
+            f"The {name} contains no positive non-zero values. Computations are likely to fail."
+        )
 
 
 def load_metadata(db, scan_num:int, det_name:str):

--- a/nsls2ptycho/core/HXN_databroker.py
+++ b/nsls2ptycho/core/HXN_databroker.py
@@ -31,6 +31,37 @@ except FileNotFoundError:
 # ************************************************************************
 
 
+def array_ensure_positive_elements(arr, name="array"):
+    """
+    Replace all zero or negative values in the array with the closest positive values.
+    Works only with 1D arrays.
+
+    Parameters
+    ----------
+    arr: numpy.ndarray
+        1D numpy array
+    name: str
+        Data name to use in error messages.
+    """
+    v_closest_positive = None
+    for v in arr:  # Initialize the algorithm with some valid value in case the 1st element is zero.
+        if v > 0:
+            v_closest_positive = v
+            break
+    if v_closest_positive is not None:
+        for n in range(arr.size):
+            if arr[n] <= 0:
+                print(
+                    f"{name.capitalize()} value {arr[n]} with index {n} is replaced "
+                    f"with the closest value {v_closest_positive}."
+                )
+                arr[n] = v_closest_positive
+            else:
+                v_closest_positive = arr[n]
+    else:
+        print(f"The {name} contains no positive non-zero values. Computations are likely to fail.")
+
+
 def load_metadata(db, scan_num:int, det_name:str):
     '''
     Get all metadata for the given scan number and detector name
@@ -102,25 +133,7 @@ def load_metadata(db, scan_num:int, det_name:str):
     else:
         angle = bl.dsth[1]
         ic = np.asfarray(df['sclr1_ch4'])
-
-    # Remove zeros from 'ic' (if possible)
-    ic_closest_nonzero = None
-    for v in ic:  # Initialize the algorithm with some valid value in case the 1st element is zero.
-        if v > 0:
-            ic_closest_nonzero = v
-            break
-    if ic_closest_nonzero is not None:
-        for n in range(ic.size):
-            if ic[n] <= 0:
-                print(
-                    f"Scaler value {ic[n]} with index {n} is replaced "
-                    f"with the closest value {ic_closest_nonzero}."
-                )
-                ic[n] = ic_closest_nonzero
-            else:
-                ic_closest_nonzero = ic[n]
-    else:
-        print("All scaler values are zero. Computation is likely to fail.")
+    array_ensure_positive_elements(ic, name="scaler")
 
     # get ccd_pixel_um
     ccd_pixel_um = 55.

--- a/nsls2ptycho/core/HXN_databroker.py
+++ b/nsls2ptycho/core/HXN_databroker.py
@@ -43,11 +43,17 @@ def array_ensure_positive_elements(arr, name="array"):
     name: str
         Data name to use in error messages.
     """
+    n_items_to_replace = sum(arr <= 0)
+    if not n_items_to_replace:
+        return
+
     v_closest_positive = None
     for v in arr:  # Initialize the algorithm with some valid value in case the 1st element is zero.
         if v > 0:
             v_closest_positive = v
             break
+
+    n_replaced = 0
     if v_closest_positive is not None:
         for n in range(arr.size):
             if arr[n] <= 0:
@@ -56,6 +62,9 @@ def array_ensure_positive_elements(arr, name="array"):
                     f"with the closest value {v_closest_positive}."
                 )
                 arr[n] = v_closest_positive
+                n_replaced += 1
+                if n_replaced == n_items_to_replace:
+                    break
             else:
                 v_closest_positive = arr[n]
     else:


### PR DESCRIPTION
Issues in data acquisition may cause zero values in scaler data. Since computations depend on scaler being positive non-zero values, all zeros need to be replaced by an appropriate positive value. In the proposed changes, a zero value is replaced by the closes preceding non-zero positive value of the scaler. If the array starts with zero(s), then those zeros are replaced with the first non-zero value of the scaler. If all scaler values are zeros, then the array remains unchanged and computations can not be completed.